### PR TITLE
fix player score bug

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -99,12 +99,12 @@ function draw() {
   }
   writer.write(']\n')
   HUD();
-  if(player1.score == LIMIT) {
+  if(player1.score >= LIMIT) {
       text("Player 1 won! Click to play again!", 200 ,200)
       replaybutton.show()
       stop=1
   }
-  if(player2.score == LIMIT) {
+  if(player2.score >= LIMIT) {
       text("Player2 won! Click to play again!", 200 ,200)
       replaybutton.show()
       stop=1


### PR DESCRIPTION
Currently the game only ends when the score of any player reaches the LIMIT variable. However, in some cases, the player score could exceed the LIMIT variable too fast (especially when playing against the bot).

Here is a screenshot of the aforementioned bug:

<img src="https://user-images.githubusercontent.com/56286157/117565887-4a45ff00-b0e6-11eb-9f21-e5abbdffbcd4.png" height="512">
